### PR TITLE
Fix tick data factory line reading

### DIFF
--- a/lib/mt4_backtester/data/tick_data_factory.rb
+++ b/lib/mt4_backtester/data/tick_data_factory.rb
@@ -34,8 +34,8 @@ module MT4Backtester
         symbol ||= 'GBPUSD'
         timeframe ||= :M1
         
-        # ファイル内容をチェックして形式を判断（先頭数行を読み込む）
-        first_lines = File.readlines(file_path, 10).map(&:strip)
+        # ファイル内容をチェックして形式を判断（先頭10行のみ読み込む）
+        first_lines = File.foreach(file_path).first(10).map(&:strip)
         
         # MT4ティックデータ形式かどうかを判断
         if first_lines.any? && first_lines[0] =~ /^\d{8}\s\d{9},\d+\.\d+,\d+\.\d+/

--- a/spec/unit/tick_data_factory_spec.rb
+++ b/spec/unit/tick_data_factory_spec.rb
@@ -1,0 +1,18 @@
+require_relative '../helpers/spec_helper'
+require 'tempfile'
+
+RSpec.describe MT4Backtester::Data::TickDataFactory do
+  describe '.create_loader' do
+    it 'detects MT4 tick data in large files with long lines' do
+      Tempfile.create('mt4_tick') do |file|
+        200.times do
+          file.puts "20220101 123456789,1.23456,1.23467"
+        end
+        file.flush
+        loader = described_class.create_loader(file.path)
+        expect(loader).to be_a(MT4Backtester::Data::MT4TickData)
+      end
+    end
+  end
+end
+


### PR DESCRIPTION
## Summary
- read only first 10 lines when detecting tick data format
- test TickDataFactory with a large file

## Testing
- `bundle exec rspec` *(fails: bundler could not find `rspec` executable)*