### PR TITLE
Fix tick data factory line reading bug

### DIFF
--- a/lib/mt4_backtester/data/tick_data_factory.rb
+++ b/lib/mt4_backtester/data/tick_data_factory.rb
@@ -35,7 +35,10 @@ module MT4Backtester
         timeframe ||= :M1
         
         # ファイル内容をチェックして形式を判断（先頭数行を読み込む）
-        first_lines = File.readlines(file_path, 10).map(&:strip)
+        # File.readlines に第二引数を渡すと行区切り文字として扱われて
+        # しまい、意図した "最初の10行" を取得できないバグがあった。
+        # そのため first(10) を用いて明示的に先頭10行だけを取得する。
+        first_lines = File.readlines(file_path).first(10).map(&:strip)
         
         # MT4ティックデータ形式かどうかを判断
         if first_lines.any? && first_lines[0] =~ /^\d{8}\s\d{9},\d+\.\d+,\d+\.\d+/


### PR DESCRIPTION
## Summary
- fix bug when reading first lines in TickDataFactory

## Testing
- `bundle exec rspec` *(fails: bundler not installed)*