### PR TITLE
Fix JPY balance handling

### DIFF
--- a/lib/mt4_backtester/strategies/trevian_strategy.rb
+++ b/lib/mt4_backtester/strategies/trevian_strategy.rb
@@ -70,8 +70,6 @@ module MT4Backtester
           symbol = trade[:symbol] || 'GBPUSD' # シンボルがなければデフォルト値
 
     # 通貨単位を明示的に設定
-    #trade[:currency] ||= "USD"
-    # 通貨単位をJPYに統一
     trade[:currency] = "JPY"
     trade[:balance_currency] = "JPY"
 
@@ -79,7 +77,7 @@ module MT4Backtester
     if !trade[:profit_jpy] && trade[:profit]
       trade[:profit_jpy] = trade[:profit] * @params[:USDJPY_rate]
     end
-    
+
     # 小数点以下の精度を統一（丸め誤差を防止）
     trade[:profit] = trade[:profit].round(5) if trade[:profit]
     trade[:profit_jpy] = trade[:profit_jpy].round(2) if trade[:profit_jpy]
@@ -108,9 +106,9 @@ module MT4Backtester
           trade[:entry_equity] = running_balance
           trade[:entry_margin] = calculate_margin(trade[:lot_size], trade[:open_price])
           trade[:entry_free_margin] = running_balance - trade[:entry_margin]
-          
+
           # 決済後の残高計算
-          running_balance += trade[:profit]
+          running_balance += (trade[:profit_jpy] || trade[:profit] * @params[:USDJPY_rate])
           
           # 決済時のポジション管理（自分を除外）
           # このトレードを見つけて除外

--- a/lib/mt4_backtester/visualization/chart_data_processor.rb
+++ b/lib/mt4_backtester/visualization/chart_data_processor.rb
@@ -99,8 +99,10 @@ module MT4Backtester
         max_balance = balance
         
         @results[:trades].each do |trade|
+          currency = trade[:currency] || @results[:params][:AccountCurrency] || 'USD'
+          profit = currency == 'JPY' ? (trade[:profit_jpy] || trade[:profit]) : trade[:profit]
           # 取引後の残高更新
-          balance += trade[:profit]
+          balance += profit
           
           # 最大残高の更新
           max_balance = balance if balance > max_balance

--- a/spec/helpers/spec_helper.rb
+++ b/spec/helpers/spec_helper.rb
@@ -1,5 +1,14 @@
 require 'rspec'
 
+# Provide a minimal Dotenv stub if the gem is unavailable
+begin
+  require 'dotenv'
+rescue LoadError
+  module Dotenv
+    def self.load; end
+  end
+end
+
 # プロジェクトルートへのパスを取得
 project_root = File.expand_path('../..', __dir__)
 

--- a/spec/unit/jpy_balance_spec.rb
+++ b/spec/unit/jpy_balance_spec.rb
@@ -1,0 +1,46 @@
+require_relative '../helpers/spec_helper'
+
+RSpec.describe 'JPY account balance handling' do
+  it 'updates balances with JPY profits' do
+    strategy = MT4Backtester::Strategies::TrevianStrategy.new({Start_Sikin: 100_000, USDJPY_rate: 155.0})
+
+    trades = [
+      {
+        open_time: Time.new(2023,1,1,0,0),
+        close_time: Time.new(2023,1,1,1,0),
+        open_price: 1.0,
+        close_price: 1.1,
+        lot_size: 1.0,
+        type: :buy,
+        profit: 100.0,
+        profit_jpy: 15_500.0,
+        currency: 'JPY'
+      },
+      {
+        open_time: Time.new(2023,1,1,2,0),
+        close_time: Time.new(2023,1,1,3,0),
+        open_price: 1.0,
+        close_price: 0.9,
+        lot_size: 1.0,
+        type: :sell,
+        profit: -50.0,
+        profit_jpy: -7_750.0,
+        currency: 'JPY'
+      }
+    ]
+
+    results = { trades: trades, params: strategy.params }
+    strategy.instance_variable_set(:@results, results)
+    strategy.send(:enhance_trade_records)
+
+    tick_data = [
+      {time: trades.first[:open_time], open:1, high:1, low:1, close:1, volume:1},
+      {time: trades.last[:close_time], open:1, high:1, low:1, close:1, volume:1}
+    ]
+
+    processor = MT4Backtester::Visualization::ChartDataProcessor.new(strategy.results, tick_data)
+    final_balance = processor.equity_curve.last[:balance]
+
+    expect(final_balance).to eq(107_750.0)
+  end
+end


### PR DESCRIPTION
## Summary
- convert USD profits to JPY when updating `running_balance`
- track entry/exit balance in JPY
- use JPY profits for equity curve when account currency is JPY
- add Dotenv fallback for specs
- cover JPY balance logic with new unit test

## Testing
- `bundle exec rspec spec` *(fails: bundler: command not found)*