### PR TITLE
Fix profit calculation

### DIFF
--- a/lib/mt4_backtester/strategies/trevian/core_logic.rb
+++ b/lib/mt4_backtester/strategies/trevian/core_logic.rb
@@ -1031,8 +1031,9 @@ end
           # 決済理由を追加
           exit_reason = get_exit_reason(position, tick)
 
-          profit_usd = profit || calculate_position_profit(position, tick, :USD)
+          # profit は円建てで計算されているため、USD 利益は別途算出する
           profit_jpy = profit
+          profit_usd = calculate_position_profit(position, tick, :USD)
           
           # トレード記録に通貨単位情報を追加
           trade = position.merge(

--- a/spec/unit/profit_conversion_spec.rb
+++ b/spec/unit/profit_conversion_spec.rb
@@ -1,0 +1,27 @@
+require_relative '../helpers/spec_helper'
+
+RSpec.describe MT4Backtester::Strategies::Trevian::CoreLogic do
+  it 'records USD and JPY profit separately' do
+    params = {
+      Start_Sikin: 100_000,
+      USDJPY_rate: 100.0,
+      Symbol: 'GBPUSD'
+    }
+    core = described_class.new(params)
+
+    position = {
+      type: :buy,
+      lot_size: 1.0,
+      open_time: Time.new(2023,1,1,0,0),
+      open_price: 1.1
+    }
+    tick = { time: Time.new(2023,1,1,1,0), close: 1.2 }
+
+    core.close_position(position, tick)
+    trade = core.instance_variable_get(:@orders).last
+
+    expect(trade[:profit_jpy]).to be_within(0.01).of(1_000_000.0)
+    expect(trade[:profit]).to be_within(0.01).of(10_000.0)
+    expect(trade[:currency]).to eq('JPY')
+  end
+end


### PR DESCRIPTION
## Summary
- fix currency conversion when closing a position so profit is stored in USD correctly
- test that profit is stored separately in USD and JPY

## Testing
- `bundle exec rspec` *(fails: bundler: command not found: rspec)*